### PR TITLE
Password Change Unit Test

### DIFF
--- a/app/src/main/java/com/example/feelgoodinc/services/UserService.java
+++ b/app/src/main/java/com/example/feelgoodinc/services/UserService.java
@@ -4,6 +4,7 @@ import android.app.Service;
 import android.content.Intent;
 import android.os.Binder;
 import android.os.IBinder;
+
 import com.example.feelgoodinc.models.User;
 import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.EmailAuthProvider;
@@ -149,7 +150,6 @@ public class UserService extends Service {
             FirebaseUser firebaseUser = mAuth.getCurrentUser();
             if(firebaseUser != null){
                 firebaseUser.reload();
-
                 AuthCredential credential = EmailAuthProvider.getCredential(Objects.requireNonNull(firebaseUser.getEmail()), oldPassword);
 
                 firebaseUser.reauthenticate(credential).addOnCompleteListener(task -> {

--- a/app/src/test/java/com/example/feelgoodinc/services/UserServiceTest.java
+++ b/app/src/test/java/com/example/feelgoodinc/services/UserServiceTest.java
@@ -15,6 +15,7 @@ import android.os.IBinder;
 
 import com.example.feelgoodinc.models.User;
 import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.AuthCredential;
 import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
@@ -182,7 +183,75 @@ public class UserServiceTest {
 
         //register user
         userServiceMock.registerUser(email, password, signUpCallback);
-  }
+
+    }
+
+    @Test
+    public void changePassword_Successful() {
+        // Mock user inputs
+        String oldPassword = "Password123!";
+        String newPassword = "NewPassword456!";
+
+        // Mock FirebaseAuth and FirebaseUser
+        FirebaseAuth mockedFirebaseAuth = mock(FirebaseAuth.class);
+        FirebaseUser mockedFirebaseUser = mock(FirebaseUser.class);
+
+        when(mockedFirebaseAuth.getCurrentUser()).thenReturn(mockedFirebaseUser);
+        when(mockedFirebaseUser.getEmail()).thenReturn("test@example.com");
+
+        // Set up the UserService with the mocked FirebaseAuth
+        UserService userServiceMock = new UserService();
+        userServiceMock.mAuth = mockedFirebaseAuth;
+
+        // Mock reauthentication Task
+        @SuppressWarnings("unchecked")
+        Task<Void> mockReauthTask = mock(Task.class);
+
+        // Mock the AuthCredential and reauthenticate method
+        when(mockedFirebaseUser.reauthenticate(any(AuthCredential.class))).thenReturn(mockReauthTask);
+
+        // Change password
+        userServiceMock.assignNewPassword(oldPassword, newPassword, signUpCallback);
+
+        // Verify callbacks
+        verify(signUpCallback, never()).onAuthError(any());
+        verify(signUpCallback, never()).onPasswordValidationError(any());
+    }
+
+
+    @Test
+    public void changePassword_Failure() {
+        // Mock user inputs
+        String oldPassword = "Password123!";
+
+        // invalid password
+        String newPassword = "newpassword456!";
+
+        // Mock FirebaseAuth and FirebaseUser
+        FirebaseAuth mockedFirebaseAuth = mock(FirebaseAuth.class);
+        FirebaseUser mockedFirebaseUser = mock(FirebaseUser.class);
+
+        when(mockedFirebaseAuth.getCurrentUser()).thenReturn(mockedFirebaseUser);
+        when(mockedFirebaseUser.getEmail()).thenReturn("test@example.com");
+
+        // Set up the UserService with the mocked FirebaseAuth
+        UserService userServiceMock = new UserService();
+        userServiceMock.mAuth = mockedFirebaseAuth;
+
+        // Mock reauthentication Task
+        @SuppressWarnings("unchecked")
+        Task<Void> mockReauthTask = mock(Task.class);
+
+        // Mock the AuthCredential and reauthenticate method
+        when(mockedFirebaseUser.reauthenticate(any(AuthCredential.class))).thenReturn(mockReauthTask);
+
+        // Change password
+        userServiceMock.assignNewPassword(oldPassword, newPassword, signUpCallback);
+
+        // Verify callbacks
+        verify(signUpCallback, never()).onAuthError(any());
+        verify(signUpCallback).onPasswordValidationError(any());
+    }
 
     @Test
     public void onBind() {


### PR DESCRIPTION
Closes #84 Closes #53 

Add tests for assigning a new password in the service (essentially just checks that password is valid as we can't test firebase auth itself)